### PR TITLE
Fix Windows Claude path and use sys.platform

### DIFF
--- a/src/claude_autoapprove/claude_autoapprove.py
+++ b/src/claude_autoapprove/claude_autoapprove.py
@@ -127,19 +127,17 @@ def start_claude(port=DEFAULT_PORT):
     """
     Start the Claude Desktop App.
     """
-    # Determine the operating system
-    os_name = platform.system()
-
     # macOS
-    if os_name == "Darwin":
+    if sys.platform == "darwin":
         subprocess.run(["open", "-a", "Claude", "--args", f"--remote-debugging-port={port}"], check=True)
 
     # Windows
-    elif os_name == "Windows":
-        subprocess.run(["start", "", "Claude", f"--remote-debugging-port={port}"], shell=True, check=True)
+    elif sys.platform == "win32":
+        claude_path = pathlib.Path(os.environ["LOCALAPPDATA"]) / "AnthropicClaude" / "claude.exe"
+        subprocess.run([str(claude_path), f"--remote-debugging-port={port}"], check=True)
 
     else:
-        raise OSError(f"Unsupported operating system: {os_name}")
+        raise OSError(f"Unsupported operating system: {sys.platform}")
 
     # Wait for the port to become available
     max_attempts = 10


### PR DESCRIPTION
- Uses `sys.platform`, just as you did in [PyneSys/claude_autoapprove_mcp](https://github.com/PyneSys/claude_autoapprove_mcp)
- Correctly set Claude path on Windows.

The Windows installer does not add claude.exe to system PATH. Also there's no "choose installation path" option, so it's guaranteed to be at `~\AppData\Local\AnthropicClaude\claude.exe`
